### PR TITLE
Gru bug fix

### DIFF
--- a/src/minimax/util/rl/rollout_storage.py
+++ b/src/minimax/util/rl/rollout_storage.py
@@ -89,8 +89,6 @@ class RolloutStorage:
 			carry_buffer = None
 		else:
 			carry_buffer = self.empty_carry
-			if len(carry_buffer) == 1:
-				carry_buffer = carry_buffer[0]
 
 		value_batch_size = (self.flat_batch_size,)
 		if self.value_ensemble_size > 1:


### PR DESCRIPTION
Fixing error caused by the first dimension of the `gru` hidden state being removed in `rollout_storage`. LSTM and S5 architectures are unaffected as their `carry_buffer` lengths are greater than 1.