### PR TITLE
[DRRunner] corrected the negative learning rate in the schedule_function in Domain Randomisation Runner

### DIFF
--- a/src/minimax/runners/dr_runner.py
+++ b/src/minimax/runners/dr_runner.py
@@ -143,14 +143,14 @@ class DRRunner:
 		params = self.student_pop.init_params(subrng, dummy_obs)
 
 		schedule_fn = optax.linear_schedule(
-			init_value=-float(self.lr),
-			end_value=-float(self.lr_final),
+			init_value=float(self.lr),
+			end_value=float(self.lr_final),
 			transition_steps=self.lr_anneal_steps,
 		)
 
 		tx = optax.chain(
 			optax.clip_by_global_norm(self.max_grad_norm),
-			optax.adam(learning_rate=float(self.lr), eps=self.adam_eps)
+			optax.adam(learning_rate=schedule_fn, eps=self.adam_eps)
 		)
 
 		train_state = VmapTrainState.create(


### PR DESCRIPTION
In the reset(self, rng) method, the learning rate seems negative as initially specified. 
This triggers the learning to break down completely. After turning it into a positive value, pass the scheduler into the optax chain (see line 153). ACCEL achieves generalisation on OOD envs [ref: WANDB attached] 

<img width="1839" alt="Screenshot 2024-08-24 at 19 21 20" src="https://github.com/user-attachments/assets/75756ab8-17ac-495a-b425-9b9b988367c5">
